### PR TITLE
Add python3-dev package to containers

### DIFF
--- a/centos/7/Dockerfile
+++ b/centos/7/Dockerfile
@@ -12,7 +12,7 @@ RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
     rm -f /lib/systemd/system/basic.target.wants/*;\
     rm -f /lib/systemd/system/anaconda.target.wants/*;
 
-RUN yum install -y epel-release python3 sudo && \
+RUN yum install -y epel-release python3 python3-dev sudo && \
     yum clean all
 
 CMD ["/usr/sbin/init"]

--- a/centos/8/Dockerfile
+++ b/centos/8/Dockerfile
@@ -13,7 +13,7 @@ RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
     rm -f /lib/systemd/system/anaconda.target.wants/*;
 
 RUN dnf config-manager --set-enabled powertools && \
-    dnf install -y --refresh epel-release python3 sudo && \
+    dnf install -y --refresh epel-release python3 python39-devel.x86_64 sudo && \
     dnf clean all
 
 CMD ["/usr/sbin/init"]

--- a/centos/9/Dockerfile
+++ b/centos/9/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/centos/centos:stream9
 ENV container docker
 
-RUN dnf install -y --refresh dnf-utils python3 sudo https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
+RUN dnf install -y --refresh dnf-utils python3 python3-devel.x86_64 sudo https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
     dnf config-manager --set-enabled crb && \
     dnf install -y epel-next-release && \
     dnf clean all

--- a/debian/10/Dockerfile
+++ b/debian/10/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:10
 ENV container docker
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends python3 sudo systemd && \
+    apt-get install -y --no-install-recommends python3 python3-dev sudo systemd && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/debian/11/Dockerfile
+++ b/debian/11/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:11
 ENV container docker
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends python3 sudo systemd && \
+    apt-get install -y --no-install-recommends python3 python3-dev sudo systemd && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/debian/9/Dockerfile
+++ b/debian/9/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:9
 ENV container docker
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends python3 sudo systemd && \
+    apt-get install -y --no-install-recommends python3 python3-dev sudo systemd && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/ubuntu/18.04/Dockerfile
+++ b/ubuntu/18.04/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 ENV container docker
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends python3 sudo systemd && \
+    apt-get install -y --no-install-recommends python3 python3-dev sudo systemd && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/ubuntu/20.04/Dockerfile
+++ b/ubuntu/20.04/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:20.04
 ENV container docker
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends python3 sudo systemd && \
+    apt-get install -y --no-install-recommends python3 python3-dev sudo systemd && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This fixes an issue with `ruamel-yaml-clib` not being able to compile.

## Description

This solves the issue mentioned in https://github.com/mrlesmithjr/ansible-frr/issues/72#issuecomment-1323426490 where the tests fail because `ruamel-yaml-clib` cannot be compiled due to missing header files.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.