### PR TITLE
remove EXTERNALLY-MANAGED file to disable PEP 668

### DIFF
--- a/debian/12/Dockerfile
+++ b/debian/12/Dockerfile
@@ -4,7 +4,8 @@ ENV container docker
 RUN apt-get update && \
     apt-get install -y --no-install-recommends python3 python3-dev sudo systemd && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    find /usr/lib/python3* -name EXTERNALLY-MANAGED -type f -delete
 
 CMD ["/lib/systemd/systemd"]
 


### PR DESCRIPTION
Debian 12 adheres to PEP 668

## Description
Delete file EXTERNALLY-MANAGED from /usr/lib/python3* to disable PEP 668

## Related Issue
https://github.com/mrlesmithjr/ansible-mariadb-galera-cluster/pull/171

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
